### PR TITLE
Remove global ng dependency

### DIFF
--- a/config/cli.ts
+++ b/config/cli.ts
@@ -1,6 +1,5 @@
-
-import { spawn } from 'child_process';
 import { Dashboard } from './dashboard';
+import { ng } from './ng';
 
 import * as packager from 'electron-packager';
 import * as gulp from 'gulp';
@@ -11,44 +10,27 @@ import * as yargs from 'yargs';
 
 const argv = yargs.argv;
 
+const ngargs =
+  [ argv.prod ? '--prod' : ''
+  , argv.aot  ? '--aot'  : ''
+  ];
+
 Dashboard.show(argv.prod ? 'prod' : 'dev');
 
 gulp.task('build', (next) => runSequence('prebuild', 'ng:build', 'postbuild', next));
 
 gulp.task('serve', (next) => runSequence('ng:serve', next));
 
-gulp.task('ng:build', (next) => {
-    const prod = argv.prod !== undefined || argv.production !== undefined;
-    const aot = argv.aot !== undefined;
-    const worker = argv.worker !== undefined || argv.webworker !== undefined;
-    const args = ['build'];
-    if (prod) { args.push('--prod'); }
-    if (aot) { args.push('--aot'); }
-    const cli_process = spawn(`ng`, args);
-    cli_process.stdout.pipe(process.stdout);
-    cli_process.stderr.pipe(process.stderr);
-    cli_process.stdout.on('close', () => { next(); });
-});
+gulp.task('ng:build', () => ng('build', ...ngargs));
 
-gulp.task('ng:serve', (next: any) => {
-    const aot = argv.aot !== undefined;
-    const args = ['serve'];
-    if (aot) { args.push('--aot'); }
-    const cli_process = spawn(`ng`, args);
-    cli_process.stdout.pipe(process.stdout);
-    cli_process.stderr.pipe(process.stderr);
-    cli_process.stdout.on('close', () => { next(); });
-});
-
+gulp.task('ng:serve', () => ng('serve', ...ngargs));
 
 gulp.task('package', (next) => runSequence('build', 'install', 'package-app', next));
 
-gulp.task('install', () => {
-    return gulp.src('./dist/package.json').pipe(install({ production: true }));
-});
+gulp.task('install', () => gulp.src('./dist/package.json').pipe(install({ production: true })));
 
-gulp.task('package-app', () => {
-    return packager({
+gulp.task('package-app', () =>
+    packager({
         dir: './dist',
         out: '_package',
         overwrite: true,
@@ -62,5 +44,5 @@ gulp.task('package-app', () => {
         } else if (appPaths) {
             console.log(appPaths.join('\n'));
         }
-    });
-});
+    })
+);

--- a/config/ng.ts
+++ b/config/ng.ts
@@ -1,0 +1,16 @@
+import { spawn } from 'child_process';
+
+const proc = (cmd, args) =>
+    new Promise((resolve, reject) => {
+        const p = spawn(cmd, args);
+        p.stdout.pipe(process.stdout);
+        p.stderr.pipe(process.stderr);
+        p.on('exit', (code, signal) => {
+            (code == 0 && resolve()) || reject(signal);
+        });
+    })
+
+const npmScript = (name) => (...args) =>
+    proc('npm', ['run-script', name, '--', ...args]);
+
+export const ng = npmScript('ng');


### PR DESCRIPTION
Wrap calls to the ng cli within the node environment so the package within the local node_modules dir is used, removing the need for it to be installed globally.